### PR TITLE
Use the env vars so devise doesn't get mad.

### DIFF
--- a/config/load.rb
+++ b/config/load.rb
@@ -35,10 +35,10 @@ github_url:                ['GITHUB_URL', lambda do |values|
   values[:github_url].gsub(%r{/*\z}, '')
 end],
 github_authentication:     ['GITHUB_AUTHENTICATION'],
-# github_client_id:          ['GITHUB_CLIENT_ID'],
-# github_secret:             ['GITHUB_SECRET'],
-# github_org_id:             ['GITHUB_ORG_ID'],
-# github_access_scope:       ['GITHUB_ACCESS_SCOPE'],
+github_client_id:          ['GITHUB_CLIENT_ID'],
+github_secret:             ['GITHUB_SECRET'],
+github_org_id:             ['GITHUB_ORG_ID'],
+github_access_scope:       ['GITHUB_ACCESS_SCOPE'],
 # github_api_url:            ['GITHUB_API_URL'],
 # github_site_title:         ['GITHUB_SITE_TITLE'],
 # google


### PR DESCRIPTION
I want to link our github accounts to errbit so that we can optionally setup issue creation through errbit. To do that, I need to set a few env vars.