### PR TITLE
Support comma seperated service urls in the slack service

### DIFF
--- a/app/models/notification_services/slack_service.rb
+++ b/app/models/notification_services/slack_service.rb
@@ -49,17 +49,23 @@ class NotificationServices::SlackService < NotificationService
   end
 
   def create_notification(problem)
-    HTTParty.post(
-      service_url,
-      body:    post_payload(problem),
-      headers: {
-        'Content-Type' => 'application/json'
-      }
-    )
+    service_urls.each do |service_url|
+      HTTParty.post(
+        service_url,
+        body:    post_payload(problem),
+        headers: {
+          'Content-Type' => 'application/json'
+        }
+      )
+    end
   end
 
   def configured?
     service_url.present?
+  end
+
+  def service_urls
+    service_url.split(",").map(&:strip).reject(&:blank?)
   end
 
 private

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -269,7 +269,7 @@ Devise.setup do |config|
 
   if Errbit::Config.github_authentication || Rails.env.test?
     github_options = {
-      scope:          Errbit::Config.github_access_scope.join(','),
+      scope:          Errbit::Config.github_access_scope&.join(','),
       skip_info:      true,
       client_options: {
         site:          Errbit::Config.github_api_url,

--- a/spec/models/notification_service/slack_service_spec.rb
+++ b/spec/models/notification_service/slack_service_spec.rb
@@ -150,4 +150,17 @@ describe NotificationServices::SlackService, type: 'model' do
       service.create_notification(problem)
     end
   end
+
+  context "with comma separate service url" do
+    let(:service_url) { "https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXX, https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXYYY"}
+
+    it "parses the service urls correctly" do
+      expect(service.service_urls).to eq ["https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXX", "https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXYYY"]
+    end
+
+    it "should send the notification to multiple slack urls" do
+      expect(HTTParty).to receive(:post).twice
+      service.create_notification(problem)
+    end
+  end
 end


### PR DESCRIPTION
For merchtable we want to send these reports to multiple places so this allows us to add multiple hook urls for slack.

An option I considered but threw out was to allow each `app` to have multiple `NotificationService`s. I think that's probably a better way to fix it but until we really need that feature I think this is a fine way to solve it.